### PR TITLE
Immediate option

### DIFF
--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -1,16 +1,24 @@
 import { writable, derived } from 'svelte/store';
 
-function createValidator({ initial, rules }) {
+function createValidator(opts) {
+  const { initial, rules } = opts;
   const validator = createValidatorFun(rules);
 
+  const configStore = writable(config(opts));
   const valueStore = writable(initial);
-  const errorStore = derived(valueStore, (value) => validator(value));
+  const errorStore = derived([valueStore, configStore], ([value, config]) => validator(value, config));
 
-  return [valueStore, errorStore]
+  const activate = () => {
+    configStore.update(config => ({ ...config, active: true }));
+  };
+
+  return [valueStore, errorStore, { activate }]
 }
 
 function createValidatorFun(rules) {
-  return (value) => {
+  return (value, config) => {
+    if (!config.active) { return {} }
+
     return rules.reduce((violated, rule) => {
       const { name, isValid, argument } = rule;
 
@@ -21,6 +29,16 @@ function createValidatorFun(rules) {
       }
     }, {})
   }
+}
+
+function config(opts) {
+  return {
+    active: fetch(opts, 'immediate', true)
+  }
+}
+
+function fetch(opts, key, fallback) {
+  return key in opts ? opts[key] : fallback
 }
 
 function required() {

--- a/src/create-validator.js
+++ b/src/create-validator.js
@@ -1,16 +1,24 @@
 import { writable, derived } from 'svelte/store'
 
-export function createValidator({ initial, rules }) {
+export function createValidator(opts) {
+  const { initial, rules } = opts
   const validator = createValidatorFun(rules)
 
+  const configStore = writable(config(opts))
   const valueStore = writable(initial)
-  const errorStore = derived(valueStore, (value) => validator(value))
+  const errorStore = derived([valueStore, configStore], ([value, config]) => validator(value, config))
 
-  return [valueStore, errorStore]
+  const activate = () => {
+    configStore.update(config => ({ ...config, active: true }))
+  }
+
+  return [valueStore, errorStore, { activate }]
 }
 
 function createValidatorFun(rules) {
-  return (value) => {
+  return (value, config) => {
+    if (!config.active) { return {} }
+
     return rules.reduce((violated, rule) => {
       const { name, isValid, argument } = rule
 
@@ -21,4 +29,14 @@ function createValidatorFun(rules) {
       }
     }, {})
   }
+}
+
+function config(opts) {
+  return {
+    active: fetch(opts, 'immediate', true)
+  }
+}
+
+function fetch(opts, key, fallback) {
+  return key in opts ? opts[key] : fallback
 }

--- a/test/create-validator.test.js
+++ b/test/create-validator.test.js
@@ -3,7 +3,7 @@ import createValidator from '../src/index'
 
 describe('createValidator', () => {
   test('returns svelte stores', () => {
-    const [valueStore, errorStore] = createValidator({ rules: [] })
+    const [valueStore, errorStore, command] = createValidator({ rules: [] })
 
     expect(valueStore).toMatchObject({
       set: expect.any(Function),
@@ -14,6 +14,8 @@ describe('createValidator', () => {
     expect(errorStore).toMatchObject({
       subscribe: expect.any(Function),
     })
+
+    expect(command).toEqual(expect.any(Object))
   })
 
   test('use given initial value', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -19,6 +19,24 @@ describe('integration', () => {
     errors = get(errorStore)
     expect(Object.keys(errors)).toEqual([])
   })
+
+  test('immediate: false delays validation until calling activate', () => {
+    const rules = [minLength(3)]
+    const [valueStore, errorStore, command] = createValidator({ rules, immediate: false })
+
+    let errors = get(errorStore)
+    expect(Object.keys(errors)).toEqual([])
+
+    valueStore.set('he')
+
+    errors = get(errorStore)
+    expect(Object.keys(errors)).toEqual([])
+
+    command.activate()
+
+    errors = get(errorStore)
+    expect(Object.keys(errors)).toEqual(expect.arrayContaining(['minLength']))
+  })
 })
 
 describe('custom validator', () => {


### PR DESCRIPTION
passing `immediate: true` to `createValidator` delays validation until calling `command.activate` function. `command` is given in 3rd element of returned array.