### PR TITLE
change confusable name options to object

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,22 +61,22 @@ For example this can be used to prevent display errors until first blur event oc
 
 ### Builtin Validators
 
-- `required(options)`
-- `equal(options)`
-- `minValue(min, options)`
-- `maxValue(max, options)`
-- `betweenValue([min, max], options)`
-- `minLength(length, options)`
-- `maxLength(length, options)`
-- `betweenLength([min, max], options)`
-- `format(regex, options)`
+- `required(object)`
+- `equal(object)`
+- `minValue(min, object)`
+- `maxValue(max, object)`
+- `betweenValue([min, max], object)`
+- `minLength(length, object)`
+- `maxLength(length, object)`
+- `betweenLength([min, max], object)`
+- `format(regex, object)`
 - `not(validator)`
 
-You can put any object on `options`. It can be accessed via `errorStore` like `$errorStore.minValue`. See implementation for more details.
+You can put any object on `object`. It can be accessed via `errorStore` like `$errorStore.minValue`. See implementation for more details.
 
 ### Custom Validator
 
-You can implement your own validator. It should be an object which has `name` and `isValid` properties, and optionally `options`.
+You can implement your own validator. It should be an object which has `name` and `isValid` properties, and optionally `object`.
 
 ```javascript
 const myRule = {
@@ -84,7 +84,7 @@ const myRule = {
   isValid: (value) => {
     // true or false
   },
-  options: {},
+  object: { message: '...', color: 'red' }
 }
 
 const [valueStore, errorStore] = createValidator({ rules: [myRule] })

--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -24,12 +24,12 @@ function createValidatorFun(rules) {
     if (!config.active) { return {} }
 
     return rules.reduce((violated, rule) => {
-      const { name, isValid, argument, options } = rule;
+      const { name, isValid, argument, object } = rule;
 
       if (isValid(value)) {
         return violated
       } else {
-        return {...violated, [name]: { ...options, argument}}
+        return {...violated, [name]: { ...object, argument}}
       }
     }, {})
   }
@@ -45,11 +45,11 @@ function fetch(opts, key, fallback) {
   return key in opts ? opts[key] : fallback
 }
 
-function required(options = {}) {
+function required(object = {}) {
   return {
     name: 'required',
     argument: undefined,
-    options,
+    object,
     isValid: (value) => {
       if (typeof value === 'string') {
         return value.trim() !== ''
@@ -60,44 +60,44 @@ function required(options = {}) {
   }
 }
 
-function equal(val, options = {}) {
+function equal(val, object = {}) {
   return {
     name: 'equal',
     argument: val,
-    options,
+    object,
     isValid: (value) => {
       return value === val
     }
   }
 }
 
-function minLength(length, options = {}) {
+function minLength(length, object = {}) {
   return {
     name: 'minLength',
     argument: length,
-    options,
+    object,
     isValid: (value) => {
       return value.length >= length
     }
   }
 }
 
-function maxLength(length, options = {}) {
+function maxLength(length, object = {}) {
   return {
     name: 'maxLength',
     argument: length,
-    options,
+    object,
     isValid: (value) => {
       return value.length <= length
     }
   }
 }
 
-function betweenLength([min, max], options = {}) {
+function betweenLength([min, max], object = {}) {
   return {
     name: 'betweenLength',
     argument: [min, max],
-    options,
+    object,
     isValid: (value) => {
       const length = value.length;
       return min <= length && length <= max
@@ -105,44 +105,44 @@ function betweenLength([min, max], options = {}) {
   }
 }
 
-function minValue(amount, options = {}) {
+function minValue(amount, object = {}) {
   return {
     name: 'minValue',
     argument: amount,
-    options,
+    object,
     isValid: (value) => {
       return value >= amount
     }
   }
 }
 
-function maxValue(amount, options = {}) {
+function maxValue(amount, object = {}) {
   return {
     name: 'maxValue',
     argument: amount,
-    options,
+    object,
     isValid: (value) => {
       return value <= amount
     }
   }
 }
 
-function betweenValue([min, max], options = {}) {
+function betweenValue([min, max], object = {}) {
   return {
     name: 'betweenValue',
     argument: [min, max],
-    options,
+    object,
     isValid: (value) => {
       return min <= value && value <= max
     }
   }
 }
 
-function format(regex, options = {}) {
+function format(regex, object = {}) {
   return {
     name: 'format',
     argument: regex,
-    options,
+    object,
     isValid: (value) => {
       return regex.test(value)
     }
@@ -167,7 +167,7 @@ function hasError(errorObject) {
   return Object.keys(errorObject).length > 0
 }
 
-function getErrorOptions(errorObject, errorNames, key = null) {
+function getErrors(errorObject, errorNames, key = null) {
   return errorNames.reduce((acc, name) => {
     if (name in errorObject) {
       const value = key ? errorObject[name][key] : errorObject[name];
@@ -183,7 +183,7 @@ exports.betweenValue = betweenValue;
 exports.default = createValidator;
 exports.equal = equal;
 exports.format = format;
-exports.getErrorOptions = getErrorOptions;
+exports.getErrors = getErrors;
 exports.hasError = hasError;
 exports.maxLength = maxLength;
 exports.maxValue = maxValue;

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -20,12 +20,12 @@ function createValidatorFun(rules) {
     if (!config.active) { return {} }
 
     return rules.reduce((violated, rule) => {
-      const { name, isValid, argument, options } = rule;
+      const { name, isValid, argument, object } = rule;
 
       if (isValid(value)) {
         return violated
       } else {
-        return {...violated, [name]: { ...options, argument}}
+        return {...violated, [name]: { ...object, argument}}
       }
     }, {})
   }
@@ -41,11 +41,11 @@ function fetch(opts, key, fallback) {
   return key in opts ? opts[key] : fallback
 }
 
-function required(options = {}) {
+function required(object = {}) {
   return {
     name: 'required',
     argument: undefined,
-    options,
+    object,
     isValid: (value) => {
       if (typeof value === 'string') {
         return value.trim() !== ''
@@ -56,44 +56,44 @@ function required(options = {}) {
   }
 }
 
-function equal(val, options = {}) {
+function equal(val, object = {}) {
   return {
     name: 'equal',
     argument: val,
-    options,
+    object,
     isValid: (value) => {
       return value === val
     }
   }
 }
 
-function minLength(length, options = {}) {
+function minLength(length, object = {}) {
   return {
     name: 'minLength',
     argument: length,
-    options,
+    object,
     isValid: (value) => {
       return value.length >= length
     }
   }
 }
 
-function maxLength(length, options = {}) {
+function maxLength(length, object = {}) {
   return {
     name: 'maxLength',
     argument: length,
-    options,
+    object,
     isValid: (value) => {
       return value.length <= length
     }
   }
 }
 
-function betweenLength([min, max], options = {}) {
+function betweenLength([min, max], object = {}) {
   return {
     name: 'betweenLength',
     argument: [min, max],
-    options,
+    object,
     isValid: (value) => {
       const length = value.length;
       return min <= length && length <= max
@@ -101,44 +101,44 @@ function betweenLength([min, max], options = {}) {
   }
 }
 
-function minValue(amount, options = {}) {
+function minValue(amount, object = {}) {
   return {
     name: 'minValue',
     argument: amount,
-    options,
+    object,
     isValid: (value) => {
       return value >= amount
     }
   }
 }
 
-function maxValue(amount, options = {}) {
+function maxValue(amount, object = {}) {
   return {
     name: 'maxValue',
     argument: amount,
-    options,
+    object,
     isValid: (value) => {
       return value <= amount
     }
   }
 }
 
-function betweenValue([min, max], options = {}) {
+function betweenValue([min, max], object = {}) {
   return {
     name: 'betweenValue',
     argument: [min, max],
-    options,
+    object,
     isValid: (value) => {
       return min <= value && value <= max
     }
   }
 }
 
-function format(regex, options = {}) {
+function format(regex, object = {}) {
   return {
     name: 'format',
     argument: regex,
-    options,
+    object,
     isValid: (value) => {
       return regex.test(value)
     }
@@ -163,7 +163,7 @@ function hasError(errorObject) {
   return Object.keys(errorObject).length > 0
 }
 
-function getErrorOptions(errorObject, errorNames, key = null) {
+function getErrors(errorObject, errorNames, key = null) {
   return errorNames.reduce((acc, name) => {
     if (name in errorObject) {
       const value = key ? errorObject[name][key] : errorObject[name];
@@ -175,4 +175,4 @@ function getErrorOptions(errorObject, errorNames, key = null) {
 }
 
 export default createValidator;
-export { betweenLength, betweenValue, equal, format, getErrorOptions, hasError, maxLength, maxValue, minLength, minValue, not, required };
+export { betweenLength, betweenValue, equal, format, getErrors, hasError, maxLength, maxValue, minLength, minValue, not, required };

--- a/src/create-validator.js
+++ b/src/create-validator.js
@@ -20,12 +20,12 @@ function createValidatorFun(rules) {
     if (!config.active) { return {} }
 
     return rules.reduce((violated, rule) => {
-      const { name, isValid, argument, options } = rule
+      const { name, isValid, argument, object } = rule
 
       if (isValid(value)) {
         return violated
       } else {
-        return {...violated, [name]: { ...options, argument}}
+        return {...violated, [name]: { ...object, argument}}
       }
     }, {})
   }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,7 +2,7 @@ export function hasError(errorObject) {
   return Object.keys(errorObject).length > 0
 }
 
-export function getErrorOptions(errorObject, errorNames, key = null) {
+export function getErrors(errorObject, errorNames, key = null) {
   return errorNames.reduce((acc, name) => {
     if (name in errorObject) {
       const value = key ? errorObject[name][key] : errorObject[name]

--- a/src/validators/between-length.js
+++ b/src/validators/between-length.js
@@ -1,8 +1,8 @@
-export function betweenLength([min, max], options = {}) {
+export function betweenLength([min, max], object = {}) {
   return {
     name: 'betweenLength',
     argument: [min, max],
-    options,
+    object,
     isValid: (value) => {
       const length = value.length
       return min <= length && length <= max

--- a/src/validators/between-value.js
+++ b/src/validators/between-value.js
@@ -1,8 +1,8 @@
-export function betweenValue([min, max], options = {}) {
+export function betweenValue([min, max], object = {}) {
   return {
     name: 'betweenValue',
     argument: [min, max],
-    options,
+    object,
     isValid: (value) => {
       return min <= value && value <= max
     }

--- a/src/validators/equal.js
+++ b/src/validators/equal.js
@@ -1,8 +1,8 @@
-export function equal(val, options = {}) {
+export function equal(val, object = {}) {
   return {
     name: 'equal',
     argument: val,
-    options,
+    object,
     isValid: (value) => {
       return value === val
     }

--- a/src/validators/format.js
+++ b/src/validators/format.js
@@ -1,8 +1,8 @@
-export function format(regex, options = {}) {
+export function format(regex, object = {}) {
   return {
     name: 'format',
     argument: regex,
-    options,
+    object,
     isValid: (value) => {
       return regex.test(value)
     }

--- a/src/validators/max-length.js
+++ b/src/validators/max-length.js
@@ -1,8 +1,8 @@
-export function maxLength(length, options = {}) {
+export function maxLength(length, object = {}) {
   return {
     name: 'maxLength',
     argument: length,
-    options,
+    object,
     isValid: (value) => {
       return value.length <= length
     }

--- a/src/validators/max-value.js
+++ b/src/validators/max-value.js
@@ -1,8 +1,8 @@
-export function maxValue(amount, options = {}) {
+export function maxValue(amount, object = {}) {
   return {
     name: 'maxValue',
     argument: amount,
-    options,
+    object,
     isValid: (value) => {
       return value <= amount
     }

--- a/src/validators/min-length.js
+++ b/src/validators/min-length.js
@@ -1,8 +1,8 @@
-export function minLength(length, options = {}) {
+export function minLength(length, object = {}) {
   return {
     name: 'minLength',
     argument: length,
-    options,
+    object,
     isValid: (value) => {
       return value.length >= length
     }

--- a/src/validators/min-value.js
+++ b/src/validators/min-value.js
@@ -1,8 +1,8 @@
-export function minValue(amount, options = {}) {
+export function minValue(amount, object = {}) {
   return {
     name: 'minValue',
     argument: amount,
-    options,
+    object,
     isValid: (value) => {
       return value >= amount
     }

--- a/src/validators/required.js
+++ b/src/validators/required.js
@@ -1,8 +1,8 @@
-export function required(options = {}) {
+export function required(object = {}) {
   return {
     name: 'required',
     argument: undefined,
-    options,
+    object,
     isValid: (value) => {
       if (typeof value === 'string') {
         return value.trim() !== ''

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,4 +1,4 @@
-import { hasError, getErrorOptions } from '../src/index'
+import { hasError, getErrors } from '../src/index'
 
 describe('hasError', () => {
   test('returns true if given object is not empty', () => {
@@ -7,14 +7,14 @@ describe('hasError', () => {
   })
 })
 
-describe('getErrorOptions', () => {
+describe('getErrors', () => {
   test('returns array of options', () => {
     const errors = {
       required: { message: 'Can not be blank' },
       minLength: { message: 'Too short.' },
     }
 
-    const options = getErrorOptions(errors, ['required', 'minLength'])
+    const options = getErrors(errors, ['required', 'minLength'])
     expect(options[0]).toEqual(errors.required)
     expect(options[1]).toEqual(errors.minLength)
     expect(options.length).toEqual(Object.keys(errors).length)
@@ -26,7 +26,7 @@ describe('getErrorOptions', () => {
       minLength: { message: 'Too short.' },
     }
 
-    const messages = getErrorOptions(errors, ['required', 'minLength'], 'message')
+    const messages = getErrors(errors, ['required', 'minLength'], 'message')
     expect(messages[0]).toEqual(errors.required.message)
     expect(messages[1]).toEqual(errors.minLength.message)
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,7 +20,7 @@ describe('integration', () => {
     expect(Object.keys(errors)).toEqual([])
   })
 
-  test('can acccess given argument and options via error store', () => {
+  test('can acccess given argument and object via error store', () => {
     const rules = [minLength(3, { message: 'Too short!'})]
     const [valueStore, errorStore] = createValidator({ initial: 'a', rules })
 

--- a/test/validators/between-length.test.js
+++ b/test/validators/between-length.test.js
@@ -2,11 +2,11 @@ import { betweenLength } from '../../src/index'
 
 describe('betweenLength', () => {
   test('return value', () => {
-    const { name, argument, options, isValid } = betweenLength([0, 10])
+    const { name, argument, object, isValid } = betweenLength([0, 10])
 
     expect(name).toEqual('betweenLength')
     expect(argument).toEqual([0, 10])
-    expect(options).toEqual(expect.any(Object))
+    expect(object).toEqual(expect.any(Object))
     expect(isValid).toEqual(expect.any(Function))
   })
 

--- a/test/validators/between-value.test.js
+++ b/test/validators/between-value.test.js
@@ -2,11 +2,11 @@ import { betweenValue } from '../../src/index'
 
 describe('betweenValue', () => {
   test('return value', () => {
-    const { name, argument, options, isValid } = betweenValue([0, 10])
+    const { name, argument, object, isValid } = betweenValue([0, 10])
 
     expect(name).toEqual('betweenValue')
     expect(argument).toEqual([0, 10])
-    expect(options).toEqual(expect.any(Object))
+    expect(object).toEqual(expect.any(Object))
     expect(isValid).toEqual(expect.any(Function))
   })
 

--- a/test/validators/equal.test.js
+++ b/test/validators/equal.test.js
@@ -2,11 +2,11 @@ import { equal } from '../../src/index'
 
 describe('equal', () => {
   test('return value', () => {
-    const { name, argument, options, isValid } = equal(10)
+    const { name, argument, object, isValid } = equal(10)
 
     expect(name).toEqual('equal')
     expect(argument).toEqual(10)
-    expect(options).toEqual(expect.any(Object))
+    expect(object).toEqual(expect.any(Object))
     expect(isValid).toEqual(expect.any(Function))
   })
 

--- a/test/validators/format.test.js
+++ b/test/validators/format.test.js
@@ -2,11 +2,11 @@ import { format } from '../../src/index'
 
 describe('format', () => {
   test('return value', () => {
-    const { name, argument, options, isValid } = format(/regex/)
+    const { name, argument, object, isValid } = format(/regex/)
 
     expect(name).toEqual('format')
     expect(argument).toEqual(/regex/)
-    expect(options).toEqual(expect.any(Object))
+    expect(object).toEqual(expect.any(Object))
     expect(isValid).toEqual(expect.any(Function))
   })
 

--- a/test/validators/max-length.test.js
+++ b/test/validators/max-length.test.js
@@ -2,11 +2,11 @@ import { maxLength } from '../../src/index'
 
 describe('maxLength', () => {
   test('return value', () => {
-    const { name, argument, options, isValid } = maxLength(10)
+    const { name, argument, object, isValid } = maxLength(10)
 
     expect(name).toEqual('maxLength')
     expect(argument).toEqual(10)
-    expect(options).toEqual(expect.any(Object))
+    expect(object).toEqual(expect.any(Object))
     expect(isValid).toEqual(expect.any(Function))
   })
 

--- a/test/validators/max-value.test.js
+++ b/test/validators/max-value.test.js
@@ -2,11 +2,11 @@ import { maxValue } from '../../src/index'
 
 describe('maxValue', () => {
   test('return value', () => {
-    const { name, argument, options, isValid } = maxValue(10)
+    const { name, argument, object, isValid } = maxValue(10)
 
     expect(name).toEqual('maxValue')
     expect(argument).toEqual(10)
-    expect(options).toEqual(expect.any(Object))
+    expect(object).toEqual(expect.any(Object))
     expect(isValid).toEqual(expect.any(Function))
   })
 

--- a/test/validators/min-length.test.js
+++ b/test/validators/min-length.test.js
@@ -2,11 +2,11 @@ import { minLength } from '../../src/index'
 
 describe('minLength', () => {
   test('return value', () => {
-    const { name, argument, options, isValid } = minLength(10)
+    const { name, argument, object, isValid } = minLength(10)
 
     expect(name).toEqual('minLength')
     expect(argument).toEqual(10)
-    expect(options).toEqual(expect.any(Object))
+    expect(object).toEqual(expect.any(Object))
     expect(isValid).toEqual(expect.any(Function))
   })
 

--- a/test/validators/min-value.test.js
+++ b/test/validators/min-value.test.js
@@ -2,11 +2,11 @@ import { minValue } from '../../src/index'
 
 describe('minValue', () => {
   test('return value', () => {
-    const { name, argument, options, isValid } = minValue(10)
+    const { name, argument, object, isValid } = minValue(10)
 
     expect(name).toEqual('minValue')
     expect(argument).toEqual(10)
-    expect(options).toEqual(expect.any(Object))
+    expect(object).toEqual(expect.any(Object))
     expect(isValid).toEqual(expect.any(Function))
   })
 

--- a/test/validators/required.test.js
+++ b/test/validators/required.test.js
@@ -2,11 +2,11 @@ import { required } from '../../src/index'
 
 describe('required', () => {
   test('return value', () => {
-    const { name, argument, options, isValid } = required()
+    const { name, argument, object, isValid } = required()
 
     expect(name).toEqual('required')
     expect(argument).toBeUndefined()
-    expect(options).toEqual(expect.any(Object))
+    expect(object).toEqual(expect.any(Object))
     expect(isValid).toEqual(expect.any(Function))
   })
 


### PR DESCRIPTION
`options` implies that it expects specific format. it's confusing.